### PR TITLE
Created handler to work with dates in json:api format

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,5 +1,6 @@
 parameters:
     json_api.listener.json_event_subscriber.class: Mango\Bundle\JsonApiBundle\EventListener\Serializer\JsonEventSubscriber
+    jms_serializer.datetime_handler.class: Mango\Bundle\JsonApiBundle\Serializer\Handler\DateHandler
 
 services:
 

--- a/Serializer/Handler/DateHandler.php
+++ b/Serializer/Handler/DateHandler.php
@@ -1,0 +1,40 @@
+<?php
+/*
+ * This file is part of the opcart software.
+ *
+ * (c) 2018, OpticsPlanet, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Mango\Bundle\JsonApiBundle\Serializer\Handler;
+
+use JMS\Serializer\Handler\DateHandler as BaseDateHandler;
+use Mango\Bundle\JsonApiBundle\MangoJsonApiBundle;
+
+/**
+ * DateHandler handler to add the same handlers for dates in json:api format as for json format
+ *
+ * @copyright 2018 OpticsPlanet, Inc
+ * @package   SabioApp
+ * @author    Vlad Yarus <vladislav.yarus@intexsys.lv>
+ */
+class DateHandler extends BaseDateHandler
+{
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribingMethods()
+    {
+        $methods = parent::getSubscribingMethods();
+        $additionalMethods = [];
+        foreach ($methods as $method) {
+            if ($method['format'] === 'json') {
+                $method['format'] = MangoJsonApiBundle::FORMAT;
+                $additionalMethods[] = $method;
+            }
+        }
+
+        return array_merge($methods, $additionalMethods);
+    }
+}

--- a/Serializer/Handler/DateHandler.php
+++ b/Serializer/Handler/DateHandler.php
@@ -1,7 +1,5 @@
 <?php
 /*
- * This file is part of the opcart software.
- *
  * (c) 2018, OpticsPlanet, Inc.
  *
  * For the full copyright and license information, please view the LICENSE
@@ -16,7 +14,6 @@ use Mango\Bundle\JsonApiBundle\MangoJsonApiBundle;
  * DateHandler handler to add the same handlers for dates in json:api format as for json format
  *
  * @copyright 2018 OpticsPlanet, Inc
- * @package   SabioApp
  * @author    Vlad Yarus <vladislav.yarus@intexsys.lv>
  */
 class DateHandler extends BaseDateHandler


### PR DESCRIPTION
There is an issue with built-in PHP classes serialization like `\DateTime`. Unfortunately, JMS does not assume that there might be other standards than `json`, `yml` or `xml`

This pull request is to fix the following error during serialization when model has DateTime object:

``
Fatal error:  Uncaught Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException: Neither the property "id" nor one of the methods "getId()", "id()", "isId()", "hasId()", "__get()" exist and have public access in class "DateTime"
``