### PR TITLE
ArrayCollection and Date handlers improvement

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -2,6 +2,7 @@ parameters:
     json_api.listener.json_event_subscriber.class: Mango\Bundle\JsonApiBundle\EventListener\Serializer\JsonEventSubscriber
     jms_serializer.datetime_handler.class: Mango\Bundle\JsonApiBundle\Serializer\Handler\DateHandler
     jms_serializer.doctrine_object_constructor.class: Mango\Bundle\JsonApiBundle\Serializer\Construction\DoctrineObjectConstructor
+    jms_serializer.array_collection_handler.class: Mango\Bundle\JsonApiBundle\Serializer\Handler\ArrayCollectionHandler
 
 services:
 

--- a/Serializer/Handler/ArrayCollectionHandler.php
+++ b/Serializer/Handler/ArrayCollectionHandler.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * (c) Steffen Brem <steffenbrem@gmail.com>
+ * (c) 2018, OpticsPlanet, Inc.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -9,9 +9,6 @@
 namespace Mango\Bundle\JsonApiBundle\Serializer\Handler;
 
 use JMS\Serializer\Handler\ArrayCollectionHandler as BaseArrayCollectionHandler;
-use JMS\Serializer\VisitorInterface;
-use Doctrine\Common\Collections\ArrayCollection;
-use JMS\Serializer\Context;
 use Mango\Bundle\JsonApiBundle\MangoJsonApiBundle;
 
 /**
@@ -36,15 +33,4 @@ class ArrayCollectionHandler extends BaseArrayCollectionHandler
         }
         return array_merge($methods, $additionalMethods);
     }
-
-//    /**
-//     * {@inheritdoc}
-//     */
-//    public function deserializeCollection(VisitorInterface $visitor, $data, array $type, Context $context)
-//    {
-//        // See above.
-//        $type['name'] = 'array';
-//
-//        return $visitor->visitArray($data, $type, $context);
-//    }
 }

--- a/Serializer/Handler/ArrayCollectionHandler.php
+++ b/Serializer/Handler/ArrayCollectionHandler.php
@@ -1,0 +1,50 @@
+<?php
+/*
+ * (c) Steffen Brem <steffenbrem@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mango\Bundle\JsonApiBundle\Serializer\Handler;
+
+use JMS\Serializer\Handler\ArrayCollectionHandler as BaseArrayCollectionHandler;
+use JMS\Serializer\VisitorInterface;
+use Doctrine\Common\Collections\ArrayCollection;
+use JMS\Serializer\Context;
+use Mango\Bundle\JsonApiBundle\MangoJsonApiBundle;
+
+/**
+ * ArrayCollectionHandler handler to add the same handlers for ArrayCollection in json:api format as for json format
+ *
+ * @author Alexander Kurbatsky <alexander.kurbatsky@intexsys.lv>
+ */
+class ArrayCollectionHandler extends BaseArrayCollectionHandler
+{
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribingMethods()
+    {
+        $methods = parent::getSubscribingMethods();
+        $additionalMethods = [];
+        foreach ($methods as $method) {
+            if ($method['format'] === 'json') {
+                $method['format'] = MangoJsonApiBundle::FORMAT;
+                $additionalMethods[] = $method;
+            }
+        }
+        return array_merge($methods, $additionalMethods);
+    }
+
+//    /**
+//     * {@inheritdoc}
+//     */
+//    public function deserializeCollection(VisitorInterface $visitor, $data, array $type, Context $context)
+//    {
+//        // See above.
+//        $type['name'] = 'array';
+//
+//        return $visitor->visitArray($data, $type, $context);
+//    }
+}

--- a/Serializer/Handler/DateHandler.php
+++ b/Serializer/Handler/DateHandler.php
@@ -7,6 +7,7 @@
  */
 namespace Mango\Bundle\JsonApiBundle\Serializer\Handler;
 
+use JMS\Serializer\GraphNavigator;
 use JMS\Serializer\Handler\DateHandler as BaseDateHandler;
 use Mango\Bundle\JsonApiBundle\MangoJsonApiBundle;
 
@@ -28,6 +29,9 @@ class DateHandler extends BaseDateHandler
         foreach ($methods as $method) {
             if ($method['format'] === 'json') {
                 $method['format'] = MangoJsonApiBundle::FORMAT;
+                if (!isset($method['method']) && $method['direction'] === GraphNavigator::DIRECTION_DESERIALIZATION) {
+                    $method['method'] = 'deserialize' . $method['type'] . 'FromJson';
+                }
                 $additionalMethods[] = $method;
             }
         }

--- a/Tests/Fixtures/GiftCoupon.php
+++ b/Tests/Fixtures/GiftCoupon.php
@@ -1,0 +1,75 @@
+<?php
+/*
+ * (c) 2018, OpticsPlanet, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mango\Bundle\JsonApiBundle\Tests\Fixtures;
+
+use JMS\Serializer\Annotation as JMS;
+use Mango\Bundle\JsonApiBundle\Configuration\Annotation as JsonApi;
+
+/**
+ * @JsonApi\Resource(type="order/coupon", showLinkSelf=false)
+ *
+ * @author Alexander Kurbatsky <alexander.kurbatsky@intexsys.lv>
+ */
+class GiftCoupon
+{
+    /**
+     * @JsonApi\Id()
+     * @JMS\Type("string")
+     *
+     * @var string
+     */
+    private $id;
+
+    /**
+     * @JMS\Type("string")
+     *
+     * @var string
+     */
+    private $coupon;
+
+    /**
+     * @return string
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param string $id
+     *
+     * @return $this
+     */
+    public function setId($id)
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCoupon()
+    {
+        return $this->coupon;
+    }
+
+    /**
+     * @param string $coupon
+     *
+     * @return $this
+     */
+    public function setCoupon($coupon)
+    {
+        $this->coupon = $coupon;
+
+        return $this;
+    }
+}

--- a/Tests/Fixtures/JsonApiSerializerBuilder.php
+++ b/Tests/Fixtures/JsonApiSerializerBuilder.php
@@ -28,6 +28,11 @@ use Metadata\Driver\FileLocator;
 use Metadata\MetadataFactory;
 use PhpCollection\Map;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Mango\Bundle\JsonApiBundle\Serializer\Handler\DateHandler;
+use JMS\Serializer\Handler\StdClassHandler;
+use JMS\Serializer\Handler\PhpCollectionHandler;
+use Mango\Bundle\JsonApiBundle\Serializer\Handler\ArrayCollectionHandler;
+use JMS\Serializer\Handler\PropelCollectionHandler;
 
 /**
  * Json api serializer builder
@@ -54,7 +59,7 @@ class JsonApiSerializerBuilder
 
         $jsonApiMetadataFactory = new MetadataFactory($jsonApiChainDriver);
         $jsonApiMetadataFactory->setCache(new NoopCache());
-        $handlerRegistry = new HandlerRegistry();
+        $handlerRegistry = self::createHandlerRegistryAndAddDefaultHandlers();
 
         $jsonApiEventSubscriber = new JsonEventSubscriber(
             $jsonApiMetadataFactory,
@@ -95,5 +100,22 @@ class JsonApiSerializerBuilder
         $exclusionStrategy = new RelationshipExclusionStrategy($jmsMetadataFactory);
 
         return new JsonApiSerializer($jmsSerializer, $exclusionStrategy);
+    }
+
+    /**
+     * Create HandlerRegistry and add default handlers
+     *
+     * @return HandlerRegistry
+     */
+    private static function createHandlerRegistryAndAddDefaultHandlers()
+    {
+        $handlerRegistry = new HandlerRegistry();
+        $handlerRegistry->registerSubscribingHandler(new DateHandler());
+        $handlerRegistry->registerSubscribingHandler(new StdClassHandler());
+        $handlerRegistry->registerSubscribingHandler(new PhpCollectionHandler());
+        $handlerRegistry->registerSubscribingHandler(new ArrayCollectionHandler());
+        $handlerRegistry->registerSubscribingHandler(new PropelCollectionHandler());
+
+        return $handlerRegistry;
     }
 }

--- a/Tests/Fixtures/Order.php
+++ b/Tests/Fixtures/Order.php
@@ -57,6 +57,14 @@ class Order
     private $address;
 
     /**
+     * @JMS\Type("DateTime")
+     * @JMS\SerializedName("date")
+     *
+     * @var \DateTime
+     */
+    private $orderDate;
+
+    /**
      * @JsonApi\Relationship(includeByDefault=true, showLinkSelf=false, showLinkRelated=false)
      * @JMS\Type("Mango\Bundle\JsonApiBundle\Tests\Fixtures\OrderPaymentAbstract")
      *
@@ -73,11 +81,20 @@ class Order
     private $items;
 
     /**
+     * @JsonApi\Relationship(includeByDefault=true, showLinkSelf=false, showLinkRelated=false)
+     * @JMS\Type("ArrayCollection<Mango\Bundle\JsonApiBundle\Tests\Fixtures\GiftCoupon>")
+     *
+     * @var GiftCoupon[]
+     */
+    private $giftCoupons;
+
+    /**
      * Order constructor
      */
     public function __construct()
     {
         $this->items = new ArrayCollection();
+        $this->giftCoupons = new ArrayCollection();
     }
 
     /**
@@ -180,6 +197,26 @@ class Order
     }
 
     /**
+     * @return \DateTime
+     */
+    public function getOrderDate()
+    {
+        return $this->orderDate;
+    }
+
+    /**
+     * @param \DateTime $orderDate
+     *
+     * @return $this
+     */
+    public function setOrderDate($orderDate)
+    {
+        $this->orderDate = $orderDate;
+
+        return $this;
+    }
+
+    /**
      * @return OrderPaymentAbstract
      */
     public function getPayment()
@@ -215,6 +252,26 @@ class Order
     public function setItems(ArrayCollection $items)
     {
         $this->items = $items;
+
+        return $this;
+    }
+
+    /**
+     * @return GiftCoupon[]
+     */
+    public function getGiftCoupons()
+    {
+        return $this->giftCoupons;
+    }
+
+    /**
+     * @param OrderItem[] $giftCoupons
+     *
+     * @return $this
+     */
+    public function setGiftCoupons($giftCoupons)
+    {
+        $this->giftCoupons = $giftCoupons;
 
         return $this;
     }

--- a/Tests/Serializer/DeserializationTest.php
+++ b/Tests/Serializer/DeserializationTest.php
@@ -107,7 +107,7 @@ class DeserializationTest extends TestCase
      *
      * @return void
      */
-    public function testDeserializeAttributesWithSerializedNameOveride()
+    public function testDeserializeAttributesWithSerializedNameOverride()
     {
         $id = 'ORDER-1';
         $orderDate = '2018-01-01T00:00:00+0300';

--- a/Tests/Serializer/DeserializationTest.php
+++ b/Tests/Serializer/DeserializationTest.php
@@ -103,6 +103,39 @@ class DeserializationTest extends TestCase
     }
 
     /**
+     * Test deserialize attributes with serialized property name overide
+     *
+     * @return void
+     */
+    public function testDeserializeAttributesWithSerializedNameOveride()
+    {
+        $id = 'ORDER-1';
+        $orderDate = '2018-01-01T00:00:00+0300';
+
+        $data = json_encode(
+            [
+                'data' => [
+                    'id'         => $id,
+                    'attributes' => [
+                        'date' => $orderDate
+                    ]
+                ]
+            ]
+        );
+
+        /** @var Order $order */
+        $order = $this->jsonApiSerializer->deserialize(
+            $data,
+            Order::class,
+            MangoJsonApiBundle::FORMAT,
+            Serializer\DeserializationContext::create()->setSerializeNull(true)
+        );
+
+        $this->assertSame($order->getId(), $id);
+        $this->assertEquals($order->getOrderDate(), new \DateTime($orderDate));
+    }
+
+    /**
      * Test deserialize single relationship
      *
      * @return void
@@ -149,5 +182,52 @@ class DeserializationTest extends TestCase
         $this->assertSame($id, $order->getId());
         $this->assertSame(true, $order->getAddress() instanceof OrderAddress);
         $this->assertSame($addressStreet, $order->getAddress()->getStreet());
+    }
+
+    /**
+     * Test deserialize ArrayCollection relationship
+     *
+     * @return void
+     */
+    public function testDeserializeArrayCollectionRelationship()
+    {
+        $id = 'ORDER-1';
+        $firstCouponId = '11';
+        $secondCouponId = '22';
+
+        $data = json_encode(
+            [
+                'data'     => [
+                    'id'            => $id,
+                    'relationships' => [
+                        'gift-coupons' => [
+                            'data' => [
+                                (object)[
+                                    'type'       => 'order/coupon',
+                                    'id'         => $firstCouponId
+                                ],
+                                (object)[
+                                    'type'       => 'order/coupon',
+                                    'id'         => $secondCouponId
+                                ]
+                            ],
+                        ],
+                    ],
+                ]
+            ]
+        );
+
+        /** @var Order $order */
+        $order = $this->jsonApiSerializer->deserialize(
+            $data,
+            Order::class,
+            MangoJsonApiBundle::FORMAT,
+            Serializer\DeserializationContext::create()->setSerializeNull(true)
+        );
+        $this->assertSame($id, $order->getId());
+
+        $giftCoupons = $order->getGiftCoupons();
+        $this->assertSame($firstCouponId, $giftCoupons[0]->getId());
+        $this->assertSame($secondCouponId, $giftCoupons[1]->getId());
     }
 }

--- a/Tests/Serializer/Handler/ArrayCollectionHandlerTest.php
+++ b/Tests/Serializer/Handler/ArrayCollectionHandlerTest.php
@@ -1,0 +1,283 @@
+<?php
+/*
+ * (c) 2018, OpticsPlanet, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mango\Bundle\JsonApiBundle\Tests\Serializer\Handler;
+
+use JMS\Serializer\GraphNavigator;
+use Mango\Bundle\JsonApiBundle\MangoJsonApiBundle;
+use Mango\Bundle\JsonApiBundle\Serializer\Handler\ArrayCollectionHandler;
+use Mango\Bundle\JsonApiBundle\Tests\TestCase;
+
+/**
+ * ArrayCollectionHandler test
+ *
+ * @author Alexander Kurbatsky <alexander.kurbatsky@intexsys.lv>
+ */
+class ArrayCollectionHandlerTest extends TestCase
+{
+    /**
+     * Test getSubscribingMethods method
+     *
+     * @return void
+     */
+    public function testGetSubscribingMethods()
+    {
+        $this->assertEquals($this->getExpectedSubscribingMethods(), ArrayCollectionHandler::getSubscribingMethods());
+    }
+
+    /**
+     * Returns expected subscribing methods
+     *
+     * @return array
+     */
+    private function getExpectedSubscribingMethods()
+    {
+        return [
+            [
+                'direction' => GraphNavigator::DIRECTION_SERIALIZATION,
+                'type'      => 'ArrayCollection',
+                'format'    => 'json',
+                'method'    => 'serializeCollection',
+            ],
+            [
+                'direction' => GraphNavigator::DIRECTION_DESERIALIZATION,
+                'type'      => 'ArrayCollection',
+                'format'    => 'json',
+                'method'    => 'deserializeCollection',
+            ],
+            [
+                'direction' => GraphNavigator::DIRECTION_SERIALIZATION,
+                'type'      => 'ArrayCollection',
+                'format'    => 'xml',
+                'method'    => 'serializeCollection',
+            ],
+            [
+                'direction' => GraphNavigator::DIRECTION_DESERIALIZATION,
+                'type'      => 'ArrayCollection',
+                'format'    => 'xml',
+                'method'    => 'deserializeCollection',
+            ],
+            [
+                'direction' => GraphNavigator::DIRECTION_SERIALIZATION,
+                'type'      => 'ArrayCollection',
+                'format'    => 'yml',
+                'method'    => 'serializeCollection',
+            ],
+            [
+                'direction' => GraphNavigator::DIRECTION_DESERIALIZATION,
+                'type'      => 'ArrayCollection',
+                'format'    => 'yml',
+                'method'    => 'deserializeCollection',
+            ],
+            [
+                'direction' => GraphNavigator::DIRECTION_SERIALIZATION,
+                'type'      => 'Doctrine\\Common\\Collections\\ArrayCollection',
+                'format'    => 'json',
+                'method'    => 'serializeCollection',
+            ],
+            [
+                'direction' => GraphNavigator::DIRECTION_DESERIALIZATION,
+                'type'      => 'Doctrine\\Common\\Collections\\ArrayCollection',
+                'format'    => 'json',
+                'method'    => 'deserializeCollection',
+            ],
+            [
+                'direction' => GraphNavigator::DIRECTION_SERIALIZATION,
+                'type'      => 'Doctrine\\Common\\Collections\\ArrayCollection',
+                'format'    => 'xml',
+                'method'    => 'serializeCollection',
+            ],
+            [
+                'direction' => GraphNavigator::DIRECTION_DESERIALIZATION,
+                'type'      => 'Doctrine\\Common\\Collections\\ArrayCollection',
+                'format'    => 'xml',
+                'method'    => 'deserializeCollection',
+            ],
+            [
+                'direction' => GraphNavigator::DIRECTION_SERIALIZATION,
+                'type'      => 'Doctrine\\Common\\Collections\\ArrayCollection',
+                'format'    => 'yml',
+                'method'    => 'serializeCollection',
+            ],
+            [
+                'direction' => GraphNavigator::DIRECTION_DESERIALIZATION,
+                'type'      => 'Doctrine\\Common\\Collections\\ArrayCollection',
+                'format'    => 'yml',
+                'method'    => 'deserializeCollection',
+            ],
+            [
+                'direction' => GraphNavigator::DIRECTION_SERIALIZATION,
+                'type'      => 'Doctrine\\ORM\\PersistentCollection',
+                'format'    => 'json',
+                'method'    => 'serializeCollection',
+            ],
+            [
+                'direction' => GraphNavigator::DIRECTION_DESERIALIZATION,
+                'type'      => 'Doctrine\\ORM\\PersistentCollection',
+                'format'    => 'json',
+                'method'    => 'deserializeCollection',
+            ],
+            [
+                'direction' => GraphNavigator::DIRECTION_SERIALIZATION,
+                'type'      => 'Doctrine\\ORM\\PersistentCollection',
+                'format'    => 'xml',
+                'method'    => 'serializeCollection',
+            ],
+            [
+                'direction' => GraphNavigator::DIRECTION_DESERIALIZATION,
+                'type'      => 'Doctrine\\ORM\\PersistentCollection',
+                'format'    => 'xml',
+                'method'    => 'deserializeCollection',
+            ],
+            [
+                'direction' => GraphNavigator::DIRECTION_SERIALIZATION,
+                'type'      => 'Doctrine\\ORM\\PersistentCollection',
+                'format'    => 'yml',
+                'method'    => 'serializeCollection',
+            ],
+            [
+                'direction' => GraphNavigator::DIRECTION_DESERIALIZATION,
+                'type'      => 'Doctrine\\ORM\\PersistentCollection',
+                'format'    => 'yml',
+                'method'    => 'deserializeCollection',
+            ],
+            [
+                'direction' => GraphNavigator::DIRECTION_SERIALIZATION,
+                'type'      => 'Doctrine\\ODM\\MongoDB\\PersistentCollection',
+                'format'    => 'json',
+                'method'    => 'serializeCollection',
+            ],
+            [
+                'direction' => GraphNavigator::DIRECTION_DESERIALIZATION,
+                'type'      => 'Doctrine\\ODM\\MongoDB\\PersistentCollection',
+                'format'    => 'json',
+                'method'    => 'deserializeCollection',
+            ],
+            [
+                'direction' => GraphNavigator::DIRECTION_SERIALIZATION,
+                'type'      => 'Doctrine\\ODM\\MongoDB\\PersistentCollection',
+                'format'    => 'xml',
+                'method'    => 'serializeCollection',
+            ],
+            [
+                'direction' => GraphNavigator::DIRECTION_DESERIALIZATION,
+                'type'      => 'Doctrine\\ODM\\MongoDB\\PersistentCollection',
+                'format'    => 'xml',
+                'method'    => 'deserializeCollection',
+            ],
+            [
+                'direction' => GraphNavigator::DIRECTION_SERIALIZATION,
+                'type'      => 'Doctrine\\ODM\\MongoDB\\PersistentCollection',
+                'format'    => 'yml',
+                'method'    => 'serializeCollection',
+            ],
+            [
+                'direction' => GraphNavigator::DIRECTION_DESERIALIZATION,
+                'type'      => 'Doctrine\\ODM\\MongoDB\\PersistentCollection',
+                'format'    => 'yml',
+                'method'    => 'deserializeCollection',
+            ],
+            [
+                'direction' => GraphNavigator::DIRECTION_SERIALIZATION,
+                'type'      => 'Doctrine\\ODM\\PHPCR\\PersistentCollection',
+                'format'    => 'json',
+                'method'    => 'serializeCollection',
+            ],
+            [
+                'direction' => GraphNavigator::DIRECTION_DESERIALIZATION,
+                'type'      => 'Doctrine\\ODM\\PHPCR\\PersistentCollection',
+                'format'    => 'json',
+                'method'    => 'deserializeCollection',
+            ],
+            [
+                'direction' => GraphNavigator::DIRECTION_SERIALIZATION,
+                'type'      => 'Doctrine\\ODM\\PHPCR\\PersistentCollection',
+                'format'    => 'xml',
+                'method'    => 'serializeCollection',
+            ],
+            [
+                'direction' => GraphNavigator::DIRECTION_DESERIALIZATION,
+                'type'      => 'Doctrine\\ODM\\PHPCR\\PersistentCollection',
+                'format'    => 'xml',
+                'method'    => 'deserializeCollection',
+            ],
+            [
+                'direction' => GraphNavigator::DIRECTION_SERIALIZATION,
+                'type'      => 'Doctrine\\ODM\\PHPCR\\PersistentCollection',
+                'format'    => 'yml',
+                'method'    => 'serializeCollection',
+            ],
+            [
+                'direction' => GraphNavigator::DIRECTION_DESERIALIZATION,
+                'type'      => 'Doctrine\\ODM\\PHPCR\\PersistentCollection',
+                'format'    => 'yml',
+                'method'    => 'deserializeCollection',
+            ],
+            [
+                'direction' => GraphNavigator::DIRECTION_SERIALIZATION,
+                'type'      => 'ArrayCollection',
+                'format'    => MangoJsonApiBundle::FORMAT,
+                'method'    => 'serializeCollection',
+            ],
+            [
+                'direction' => GraphNavigator::DIRECTION_DESERIALIZATION,
+                'type'      => 'ArrayCollection',
+                'format'    => MangoJsonApiBundle::FORMAT,
+                'method'    => 'deserializeCollection',
+            ],
+            [
+                'direction' => GraphNavigator::DIRECTION_SERIALIZATION,
+                'type'      => 'Doctrine\\Common\\Collections\\ArrayCollection',
+                'format'    => MangoJsonApiBundle::FORMAT,
+                'method'    => 'serializeCollection',
+            ],
+            [
+                'direction' => GraphNavigator::DIRECTION_DESERIALIZATION,
+                'type'      => 'Doctrine\\Common\\Collections\\ArrayCollection',
+                'format'    => MangoJsonApiBundle::FORMAT,
+                'method'    => 'deserializeCollection',
+            ],
+            [
+                'direction' => GraphNavigator::DIRECTION_SERIALIZATION,
+                'type'      => 'Doctrine\\ORM\\PersistentCollection',
+                'format'    => MangoJsonApiBundle::FORMAT,
+                'method'    => 'serializeCollection',
+            ],
+            [
+                'direction' => GraphNavigator::DIRECTION_DESERIALIZATION,
+                'type'      => 'Doctrine\\ORM\\PersistentCollection',
+                'format'    => MangoJsonApiBundle::FORMAT,
+                'method'    => 'deserializeCollection',
+            ],
+            [
+                'direction' => GraphNavigator::DIRECTION_SERIALIZATION,
+                'type'      => 'Doctrine\\ODM\\MongoDB\\PersistentCollection',
+                'format'    => MangoJsonApiBundle::FORMAT,
+                'method'    => 'serializeCollection',
+            ],
+            [
+                'direction' => GraphNavigator::DIRECTION_DESERIALIZATION,
+                'type'      => 'Doctrine\\ODM\\MongoDB\\PersistentCollection',
+                'format'    => MangoJsonApiBundle::FORMAT,
+                'method'    => 'deserializeCollection',
+            ],
+            [
+                'direction' => GraphNavigator::DIRECTION_SERIALIZATION,
+                'type'      => 'Doctrine\\ODM\\PHPCR\\PersistentCollection',
+                'format'    => MangoJsonApiBundle::FORMAT,
+                'method'    => 'serializeCollection',
+            ],
+            [
+                'direction' => GraphNavigator::DIRECTION_DESERIALIZATION,
+                'type'      => 'Doctrine\\ODM\\PHPCR\\PersistentCollection',
+                'format'    => MangoJsonApiBundle::FORMAT,
+                'method'    => 'deserializeCollection',
+            ]
+        ];
+    }
+}

--- a/Tests/Serializer/Handler/DateHandlerTest.php
+++ b/Tests/Serializer/Handler/DateHandlerTest.php
@@ -1,0 +1,178 @@
+<?php
+/*
+ * (c) 2018, OpticsPlanet, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mango\Bundle\JsonApiBundle\Tests\Serializer\Handler;
+
+use JMS\Serializer\GraphNavigator;
+use Mango\Bundle\JsonApiBundle\MangoJsonApiBundle;
+use Mango\Bundle\JsonApiBundle\Serializer\Handler\DateHandler;
+use Mango\Bundle\JsonApiBundle\Tests\TestCase;
+
+/**
+ * DateHandlerTest test
+ *
+ * @author Alexander Kurbatsky <alexander.kurbatsky@intexsys.lv>
+ */
+class DateHandlerTest extends TestCase
+{
+    /**
+     * Test getSubscribingMethods method
+     *
+     * @return void
+     */
+    public function testGetSubscribingMethods()
+    {
+        $this->assertEquals($this->getExpectedSubscribingMethods(), DateHandler::getSubscribingMethods());
+    }
+
+    /**
+     * Returns expected subscribing methods
+     *
+     * @return array
+     */
+    private function getExpectedSubscribingMethods()
+    {
+        return [
+            [
+                'type'      => 'DateTime',
+                'direction' => GraphNavigator::DIRECTION_DESERIALIZATION,
+                'format'    => 'json',
+            ],
+            [
+                'type'      => 'DateTimeImmutable',
+                'direction' => GraphNavigator::DIRECTION_DESERIALIZATION,
+                'format'    => 'json',
+            ],
+            [
+                'type'      => 'DateInterval',
+                'direction' => GraphNavigator::DIRECTION_DESERIALIZATION,
+                'format'    => 'json',
+            ],
+            [
+                'type'      => 'DateTime',
+                'format'    => 'json',
+                'direction' => GraphNavigator::DIRECTION_SERIALIZATION,
+                'method'    => 'serializeDateTime',
+            ],
+            [
+                'type'      => 'DateTimeImmutable',
+                'format'    => 'json',
+                'direction' => GraphNavigator::DIRECTION_SERIALIZATION,
+                'method'    => 'serializeDateTimeImmutable',
+            ],
+            [
+                'type'      => 'DateInterval',
+                'format'    => 'json',
+                'direction' => GraphNavigator::DIRECTION_SERIALIZATION,
+                'method'    => 'serializeDateInterval',
+            ],
+            [
+                'type'      => 'DateTime',
+                'direction' => GraphNavigator::DIRECTION_DESERIALIZATION,
+                'format'    => 'xml',
+            ],
+            [
+                'type'      => 'DateTimeImmutable',
+                'direction' => GraphNavigator::DIRECTION_DESERIALIZATION,
+                'format'    => 'xml',
+            ],
+            [
+                'type'      => 'DateInterval',
+                'direction' => GraphNavigator::DIRECTION_DESERIALIZATION,
+                'format'    => 'xml',
+            ],
+            [
+                'type'      => 'DateTime',
+                'format'    => 'xml',
+                'direction' => GraphNavigator::DIRECTION_SERIALIZATION,
+                'method'    => 'serializeDateTime',
+            ],
+            [
+                'type'      => 'DateTimeImmutable',
+                'format'    => 'xml',
+                'direction' => GraphNavigator::DIRECTION_SERIALIZATION,
+                'method'    => 'serializeDateTimeImmutable',
+            ],
+            [
+                'type'      => 'DateInterval',
+                'format'    => 'xml',
+                'direction' => GraphNavigator::DIRECTION_SERIALIZATION,
+                'method'    => 'serializeDateInterval',
+            ],
+            [
+                'type'      => 'DateTime',
+                'direction' => GraphNavigator::DIRECTION_DESERIALIZATION,
+                'format'    => 'yml',
+            ],
+            [
+                'type'      => 'DateTimeImmutable',
+                'direction' => GraphNavigator::DIRECTION_DESERIALIZATION,
+                'format'    => 'yml',
+            ],
+            [
+                'type'      => 'DateInterval',
+                'direction' => GraphNavigator::DIRECTION_DESERIALIZATION,
+                'format'    => 'yml',
+            ],
+            [
+                'type'      => 'DateTime',
+                'format'    => 'yml',
+                'direction' => GraphNavigator::DIRECTION_SERIALIZATION,
+                'method'    => 'serializeDateTime',
+            ],
+            [
+                'type'      => 'DateTimeImmutable',
+                'format'    => 'yml',
+                'direction' => GraphNavigator::DIRECTION_SERIALIZATION,
+                'method'    => 'serializeDateTimeImmutable',
+            ],
+            [
+                'type'      => 'DateInterval',
+                'format'    => 'yml',
+                'direction' => GraphNavigator::DIRECTION_SERIALIZATION,
+                'method'    => 'serializeDateInterval',
+            ],
+            [
+                'type'      => 'DateTime',
+                'direction' => GraphNavigator::DIRECTION_DESERIALIZATION,
+                'format'    => MangoJsonApiBundle::FORMAT,
+                'method'    => 'deserializeDateTimeFromJson',
+            ],
+            [
+                'type'      => 'DateTimeImmutable',
+                'direction' => GraphNavigator::DIRECTION_DESERIALIZATION,
+                'format'    => MangoJsonApiBundle::FORMAT,
+                'method'    => 'deserializeDateTimeImmutableFromJson',
+            ],
+            [
+                'type'      => 'DateInterval',
+                'direction' => GraphNavigator::DIRECTION_DESERIALIZATION,
+                'format'    => MangoJsonApiBundle::FORMAT,
+                'method'    => 'deserializeDateIntervalFromJson',
+            ],
+            [
+                'type'      => 'DateTime',
+                'format'    => MangoJsonApiBundle::FORMAT,
+                'direction' => GraphNavigator::DIRECTION_SERIALIZATION,
+                'method'    => 'serializeDateTime',
+            ],
+            [
+                'type'      => 'DateTimeImmutable',
+                'format'    => MangoJsonApiBundle::FORMAT,
+                'direction' => GraphNavigator::DIRECTION_SERIALIZATION,
+                'method'    => 'serializeDateTimeImmutable',
+            ],
+            [
+                'type'      => 'DateInterval',
+                'format'    => MangoJsonApiBundle::FORMAT,
+                'direction' => GraphNavigator::DIRECTION_SERIALIZATION,
+                'method'    => 'serializeDateInterval',
+            ]
+        ];
+    }
+}

--- a/Tests/Serializer/SerializerTest.php
+++ b/Tests/Serializer/SerializerTest.php
@@ -65,6 +65,7 @@ class SerializerTest extends TestCase
                     'email' => 'test@example.com',
                     'phone' => '+440000000000',
                     'admin-comments' => 'Test comments that might be longer that ordinary text.',
+                    'date' => null
                 ],
                 'relationships' => [
                     'address' => [
@@ -74,6 +75,9 @@ class SerializerTest extends TestCase
                         'data' => null,
                     ],
                     'items' => [
+                        'data' => [],
+                    ],
+                    'gift-coupons' => [
                         'data' => [],
                     ]
                 ],
@@ -97,7 +101,8 @@ class SerializerTest extends TestCase
             ->setEmail('test@example.com')
             ->setPhone('+440000000000')
             ->setAdminComments('Test comments that might be longer that ordinary text.')
-            ->setAddress($orderAddress);
+            ->setAddress($orderAddress)
+            ->setOrderDate(new \DateTime('2018-01-01T00:00:00+0300'));
 
         $serialized = $this->jsonApiSerializer->serialize(
             $order,
@@ -113,6 +118,7 @@ class SerializerTest extends TestCase
                     'email' => 'test@example.com',
                     'phone' => '+440000000000',
                     'admin-comments' => 'Test comments that might be longer that ordinary text.',
+                    'date' => '2018-01-01T00:00:00+0300'
                 ],
                 'relationships' => [
                     'address' => [
@@ -125,6 +131,9 @@ class SerializerTest extends TestCase
                         'data' => null,
                     ],
                     'items' => [
+                        'data' => [],
+                    ],
+                    'gift-coupons' => [
                         'data' => [],
                     ]
                 ],
@@ -166,6 +175,7 @@ class SerializerTest extends TestCase
             ->setPhone('+440000000000')
             ->setAdminComments('Test comments that might be longer that ordinary text.')
             ->setAddress($orderAddress)
+            ->setOrderDate(new \DateTime('2018-01-01T00:00:00+0300'))
             ->setItems(new ArrayCollection([$orderItem1, $orderItem2]));
 
         $serialized = $this->jsonApiSerializer->serialize(
@@ -182,6 +192,7 @@ class SerializerTest extends TestCase
                     'email' => 'test@example.com',
                     'phone' => '+440000000000',
                     'admin-comments' => 'Test comments that might be longer that ordinary text.',
+                    'date' => '2018-01-01T00:00:00+0300'
                 ],
                 'relationships' => [
                     'address' => [
@@ -204,6 +215,9 @@ class SerializerTest extends TestCase
                                 'id' => '2',
                             ],
                         ]
+                    ],
+                    'gift-coupons' => [
+                        'data' => [],
                     ]
                 ],
             ],


### PR DESCRIPTION
This pull request is to fix the following problems:
- issue with ArrayCollection serialization using json:api format
- improved DateTime deserialization, because original JMS DateHandler class has 'deserializeDateTimeFromJson' method and json:api format should also use this method
- improved deserialization object property naming - in case when property contains uppercase letter JsonAPI should use JMS serialized property name instead of model name