### PR TITLE
Fixed exception serialization according to JSON:API specs

### DIFF
--- a/Serializer/Handler/ExceptionHandler.php
+++ b/Serializer/Handler/ExceptionHandler.php
@@ -38,6 +38,7 @@ class ExceptionHandler implements SubscribingHandlerInterface
 
     /**
      * Serialize exception
+     * @see http://jsonapi.org/format/#error-objects
      *
      * @param JsonSerializationVisitor $visitor
      * @param \Exception               $exception
@@ -47,10 +48,11 @@ class ExceptionHandler implements SubscribingHandlerInterface
     public function serializeException(JsonSerializationVisitor $visitor, \Exception $exception)
     {
         $data = [
-            'status' => Response::HTTP_BAD_REQUEST,
-            'code'   => $exception->getCode(),
+            // all these values should be a string according to spec
+            'status' => (string) Response::HTTP_BAD_REQUEST,
+            'code'   => (string) $exception->getCode(),
             'title'  => 'Exception has been thrown',
-            'detail' => $exception->getMessage()
+            'detail' => (string) $exception->getMessage()
         ];
 
         if (null === $visitor->getRoot()) {

--- a/Serializer/JsonApiSerializationVisitor.php
+++ b/Serializer/JsonApiSerializationVisitor.php
@@ -118,7 +118,7 @@ class JsonApiSerializationVisitor extends JsonSerializationVisitor
             ];
         } elseif ($data instanceof \Exception) {
             $root = [
-                'errors' => $data,
+                'errors' => [$data],
             ];
         } else {
             $root = [

--- a/Tests/Fixtures/JsonApiSerializerBuilder.php
+++ b/Tests/Fixtures/JsonApiSerializerBuilder.php
@@ -19,6 +19,7 @@ use Mango\Bundle\JsonApiBundle\EventListener\Serializer\JsonEventSubscriber;
 use Mango\Bundle\JsonApiBundle\MangoJsonApiBundle;
 use Mango\Bundle\JsonApiBundle\Resolver\BaseUri\BaseUriResolver;
 use Mango\Bundle\JsonApiBundle\Serializer\Exclusion\RelationshipExclusionStrategy;
+use Mango\Bundle\JsonApiBundle\Serializer\Handler\ExceptionHandler;
 use Mango\Bundle\JsonApiBundle\Serializer\JsonApiDeserializationVisitor;
 use Mango\Bundle\JsonApiBundle\Serializer\JsonApiSerializationVisitor;
 use Mango\Bundle\JsonApiBundle\Serializer\Serializer as JsonApiSerializer;
@@ -115,6 +116,7 @@ class JsonApiSerializerBuilder
         $handlerRegistry->registerSubscribingHandler(new PhpCollectionHandler());
         $handlerRegistry->registerSubscribingHandler(new ArrayCollectionHandler());
         $handlerRegistry->registerSubscribingHandler(new PropelCollectionHandler());
+        $handlerRegistry->registerSubscribingHandler(new ExceptionHandler());
 
         return $handlerRegistry;
     }

--- a/Tests/Serializer/SerializerTest.php
+++ b/Tests/Serializer/SerializerTest.php
@@ -360,4 +360,28 @@ class SerializerTest extends TestCase
             ]
         ]);
     }
+
+    /**
+     * Test serialize exception
+     *
+     * @return void
+     */
+    public function testSerializeException()
+    {
+        $serialized = $this->jsonApiSerializer->serialize(
+            new \Exception('Some exception'),
+            MangoJsonApiBundle::FORMAT
+        );
+
+        $this->assertSame(json_decode($serialized, 1), [
+            'errors' => [
+                [
+                    'status' => '400',
+                    'code' => '0',
+                    'title' => 'Exception has been thrown',
+                    'detail' => 'Some exception'
+                ],
+            ]
+        ]);
+    }
 }


### PR DESCRIPTION
Fixed exception serialization according to JSON:API specs (errors always is an array, all error object properties are strings)