### PR TITLE
Fix priority of exception handler

### DIFF
--- a/EventListener/ExceptionSubscriber.php
+++ b/EventListener/ExceptionSubscriber.php
@@ -73,7 +73,7 @@ class ExceptionSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         return [
-            KernelEvents::EXCEPTION => array('onKernelException', 10),
+            KernelEvents::EXCEPTION => array('onKernelException', 0),
         ];
     }
 


### PR DESCRIPTION
Fix priority of exception handler to execute after `\Symfony\Component\Security\Http\Firewall\ExceptionListener` (priority of Firewall ExceptionListener is `1`)