### PR TITLE
Adjusted ExceptionSubscriber logging and error response behavior

### DIFF
--- a/EventListener/ExceptionSubscriber.php
+++ b/EventListener/ExceptionSubscriber.php
@@ -110,7 +110,7 @@ class ExceptionSubscriber implements EventSubscriberInterface
             MangoJsonApiBundle::FORMAT
         );
 
-        $event->setResponse(new JsonApiResponse($content, $this->decideResponseStatusCode($exception)));
+        $event->setResponse(new JsonApiResponse($content, $this->chooseResponseStatusCode($exception)));
         $event->stopPropagation();
     }
 
@@ -132,13 +132,13 @@ class ExceptionSubscriber implements EventSubscriberInterface
     }
 
     /**
-     * Decides which response status code should be sent based on the exception
+     * Chooses which response status code should be sent based on the exception
      *
      * @param Exception $exception
      *
      * @return int
      */
-    private function decideResponseStatusCode(Exception $exception): int
+    private function chooseResponseStatusCode(Exception $exception): int
     {
         if ($exception instanceof ConstraintViolationException) {
             return JsonApiResponse::HTTP_BAD_REQUEST;

--- a/EventListener/ExceptionSubscriber.php
+++ b/EventListener/ExceptionSubscriber.php
@@ -128,7 +128,7 @@ class ExceptionSubscriber implements EventSubscriberInterface
             return;
         }
 
-        $this->logger->error($message, ['exception' => $exception]);
+        $this->logger->critical($message, ['exception' => $exception]);
     }
 
     /**

--- a/EventListener/ExceptionSubscriber.php
+++ b/EventListener/ExceptionSubscriber.php
@@ -94,16 +94,7 @@ class ExceptionSubscriber implements EventSubscriberInterface
 
         $exception = $event->getException();
 
-        $this->logException(
-            $exception,
-            sprintf(
-                'Uncaught PHP Exception %s: "%s" at %s line %s',
-                get_class($exception),
-                $exception->getMessage(),
-                $exception->getFile(),
-                $exception->getLine()
-            )
-        );
+        $this->logException($exception, 'Uncaught PHP Exception');
 
         $content = $this->serializer->serialize(
             $exception,
@@ -128,7 +119,18 @@ class ExceptionSubscriber implements EventSubscriberInterface
             return;
         }
 
-        $this->logger->critical($message, ['exception' => $exception]);
+        $this->logger->critical(
+            $message,
+            [
+                'exception'         => $exception,
+                'exception_class'   => get_class($exception),
+                'exception_code'    => $exception->getCode(),
+                'exception_message' => $exception->getMessage(),
+                'exception_file'    => $exception->getFile(),
+                'exception_line'    => $exception->getLine(),
+                'exception_trace'   => $exception->getTraceAsString(),
+            ]
+        );
     }
 
     /**


### PR DESCRIPTION
**This PR contains 2 changes to ExceptionSubscriber**:
1. Logging has been adjusted to be more like Symfony's default exception logger
2. HTTP Response code on uncaught exception has been changed to 500, except when there are constraint violations when saving entity

**Reasons for changing logging behavior**:
1. Critical logging level seems more appropriate than warning for uncaught exceptions
2. Allows applications that are configured to write logs only when error+ level log entries are written to log occurred exceptions
3. Allows better compatibility with log formatters